### PR TITLE
Infer blocks

### DIFF
--- a/src/inferencer/constraintStore.ts
+++ b/src/inferencer/constraintStore.ts
@@ -86,7 +86,7 @@ function solveConstraint(constraintLhs: Type, constraintRhs: Type): any | undefi
       isTypeVariable(constraintStore.get(constraintRhs)) &&
       !constraintStore.get(constraintRhs).isAddable
     ) {
-      (constraintStore.get(constraintRhs) as Variable).isAddable = true
+      ;(constraintStore.get(constraintRhs) as Variable).isAddable = true
     }
     return solveConstraint(constraintLhs, constraintStore.get(constraintRhs))
   }

--- a/src/inferencer/inferencer.ts
+++ b/src/inferencer/inferencer.ts
@@ -36,8 +36,6 @@ function inferLiteral(literal: TypeAnnotatedNode<es.Literal>) {
     literal.inferredType = booleanType
   } else if (typeof valueOfLiteral === 'string') {
     literal.inferredType = stringType
-  } else if (typeof valueOfLiteral === 'undefined') {
-    literal.inferredType = undefinedType
   } else {
     literal.typability = 'Untypable'
     return
@@ -46,7 +44,6 @@ function inferLiteral(literal: TypeAnnotatedNode<es.Literal>) {
   // e.g. Given: 1^T2, Set: T2 = number
   // e.g. Given: true^T2, Set: T2 = boolean
   // e.g. Given: 'hi'^T2, Set: T2 = string
-  // todo: undefined gives an object in type environment, handle properly
   addTypeConstraintForLiteralPrimitive(literal)
 }
 
@@ -54,7 +51,7 @@ function inferIdentifier(identifier: TypeAnnotatedNode<es.Identifier>) {
   // Update type constraints in constraintStore
   // e.g. Given: x^T2, Set: T2 = Γ[x]
   const idenTypeVariable = identifier.typeVariable as Variable
-  const idenTypeEnvType = primitiveMap.get(identifier.name).types[0] // Type obj
+  const idenTypeEnvType = primitiveMap.get(identifier.name).types[0]
 
   if (idenTypeVariable !== undefined && idenTypeEnvType !== undefined) {
     const result = updateTypeConstraints(idenTypeVariable, idenTypeEnvType)
@@ -66,7 +63,7 @@ function inferIdentifier(identifier: TypeAnnotatedNode<es.Identifier>) {
     }
   }
 
-  // declare - Todo: do I need to declare? TBC
+  // TODO: do I need to declare? TBC
   // - not necessary since it itself is 'not a type'? e.g. 'x;' -> there's no type to x? - TBC
   // identifier.inferredType = {
   //   kind: '??',
@@ -96,7 +93,7 @@ function inferConstantDeclaration(constantDeclaration: TypeAnnotatedNode<es.Vari
 
   // if manage to pass step 3, means no type error
 
-  // declare - Todo: do I need to declare? TBC
+  // declare - TODO: do I need to declare? TBC
   // - not necessary since no one is dependent on constantDeclaration's inferredType?? - TBC
   // - plus not sure what to put in 'kind' and 'name' also
   // constantDeclaration.inferredType = {
@@ -172,10 +169,10 @@ function inferBinaryExpression(binaryExpression: TypeAnnotatedNode<es.BinaryExpr
 
   // Update type constraints in constraintStore
   // e.g. Given: (x^T1 * 1^T2)^T3, Set: T1 = number, T2 = number, T3 = number
-  const param1 = binaryExpression.left as TypeAnnotatedNode<es.Node> // can be identifier or literal or something else?
+  const param1 = binaryExpression.left as TypeAnnotatedNode<es.Node>
   const param1TypeVariable = param1.typeVariable as Variable
 
-  const param2 = binaryExpression.right as TypeAnnotatedNode<es.Node> // can be identifier or literal or something else?
+  const param2 = binaryExpression.right as TypeAnnotatedNode<es.Node>
   const param2TypeVariable = param2.typeVariable as Variable
 
   const resultTypeVariable = binaryExpression.typeVariable as Variable
@@ -188,7 +185,7 @@ function inferBinaryExpression(binaryExpression: TypeAnnotatedNode<es.BinaryExpr
           `Expecting type \`${param1Type.name}\` but got \`${result.constraintRhs.name}\` instead`,
           param1.loc
         )
-      else displayErrorAndTerminate('Polymorphic type error, error msg TBC', param1.loc)
+      else displayErrorAndTerminate('Polymorphic type error when type checking first argument, error msg TBC', param1.loc)
     }
   }
 
@@ -200,7 +197,7 @@ function inferBinaryExpression(binaryExpression: TypeAnnotatedNode<es.BinaryExpr
           `Expecting type \`${param2Type.name}\` but got \`${result.constraintRhs.name}\` instead`,
           param2.loc
         )
-      else displayErrorAndTerminate('Polymorphic type error, error msg TBC', param2.loc)
+      else displayErrorAndTerminate('Polymorphic type error when type checking second argument, error msg TBC', param2.loc)
     }
   }
 
@@ -216,7 +213,7 @@ function inferBinaryExpression(binaryExpression: TypeAnnotatedNode<es.BinaryExpr
     }
   }
 
-  // declare - Todo: do I need to declare? TBC
+  // declare - TODO: do I need to declare? TBC
   // binaryExpression.inferredType = {
   //   kind : 'primitive',
   //   name: resultType
@@ -233,7 +230,6 @@ function inferConditionals(
   const alternate = conditionalExpression.alternate as TypeAnnotatedNode<es.Expression>
 
   // check that the type of the test expression is boolean
-  // const testTypeVariable = (test.typeVariable as Variable).id
   const testTypeVariable = test.typeVariable as Variable
   if (testTypeVariable !== undefined) {
     const result = updateTypeConstraints(testTypeVariable, booleanType)
@@ -370,7 +366,6 @@ function inferFunctionApplication(functionApplication: TypeAnnotatedNode<es.Call
   }
 
   for (let i = 0; i < applicationArgs.length; i++) {
-    // add type constraint for each arg
     const applicationArgTypeVariable = applicationArgs[i].typeVariable as Variable
     const declarationArgTypeVariable = declarationFunctionType.parameterTypes[i]
       .typeVariable as Variable
@@ -406,9 +401,7 @@ function inferFunctionApplication(functionApplication: TypeAnnotatedNode<es.Call
 function addTypeConstraintForLiteralPrimitive(literal: TypeAnnotatedNode<es.Literal>) {
   // Update type constraints in constraintStore
   // e.g. Given: 1^T2, Set: T2 = number
-  // const lhsVariableId = (literal.typeVariable as Variable).id
   const literalTypeVariable = literal.typeVariable as Variable
-  // const rhsType = (literal.inferredType as Primitive).name
   const literalType = literal.inferredType as Primitive
 
   if (literalTypeVariable !== undefined && literalType !== undefined) {

--- a/src/inferencer/inferencer.ts
+++ b/src/inferencer/inferencer.ts
@@ -480,7 +480,7 @@ function inferBlockStatement(block: TypeAnnotatedNode<es.BlockStatement>, enviro
   currentTypeEnvironment = extendEnvironment(environmentToExtend)
   const blockTypeVariable = block.typeVariable
   for (const expression of block.body) {
-    infer(expression, environmentToExtend)
+    infer(expression, currentTypeEnvironment)
     if (expression.type === 'ReturnStatement') {
       const returnStatementTypeVariable = (expression as TypeAnnotatedNode<es.ReturnStatement>).typeVariable
       if (returnStatementTypeVariable !== undefined && blockTypeVariable !== undefined) {
@@ -582,6 +582,7 @@ function infer(statement: es.Node, environmentToExtend: Map<any, any> = emptyMap
       infer(statement.body, parameters)
       currentTypeEnvironment = extendEnvironment(parameters)
       inferFunctionDeclaration(statement)
+      currentTypeEnvironment = popEnvironment()
       return
     }
     case 'CallExpression': {

--- a/src/inferencer/inferencer.ts
+++ b/src/inferencer/inferencer.ts
@@ -573,9 +573,9 @@ function infer(statement: es.Node, environmentToExtend: Map<any, any> = emptyMap
       return
     }
     case 'IfStatement': {
-      infer(statement.test)
-      infer(statement.alternate!)
-      infer(statement.consequent)
+      infer(statement.test, environmentToExtend)
+      infer(statement.alternate!, environmentToExtend)
+      infer(statement.consequent, environmentToExtend)
       inferConditionals(statement)
       return
     }

--- a/src/inferencer/inferencer.ts
+++ b/src/inferencer/inferencer.ts
@@ -451,6 +451,32 @@ function replaceTypeVariablesWithFreshTypeVariables(parent: Type, tmpMap: Map<Ty
   }
 }
 
+function ifStatementHasReturnStatements(ifStatement: TypeAnnotatedNode<es.IfStatement>): boolean {
+  const consequent = ifStatement.consequent as TypeAnnotatedNode<es.BlockStatement>
+  const alternate = ifStatement.alternate as TypeAnnotatedNode<es.BlockStatement>
+
+  return blockStatementHasReturnStatements(consequent) || blockStatementHasReturnStatements(alternate)
+}
+
+function blockStatementHasReturnStatements(block: TypeAnnotatedNode<es.BlockStatement>): boolean {
+  for (const statement of block.body) {
+    if (statement.type === 'ReturnStatement') {
+      return true
+    }
+    if (statement.type === 'IfStatement') {
+      if (ifStatementHasReturnStatements(statement)) {
+        return true
+      }
+    }
+    if (statement.type === 'BlockStatement') {
+      if (blockStatementHasReturnStatements(statement)) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
 function inferBlockStatement(block: TypeAnnotatedNode<es.BlockStatement>, environmentToExtend: Map<any, any>) {
   // TODO: Implement type environment scoping
   extendEnvironment(environmentToExtend)
@@ -468,8 +494,21 @@ function inferBlockStatement(block: TypeAnnotatedNode<es.BlockStatement>, enviro
             'WARNING: There is a type error when checking the type of a block', block.loc
           )
         }
-        popEnvironment()
-        currentTypeEnvironment = environments[0]
+        return
+      }
+    }
+
+    if (expression.type === 'IfStatement' && ifStatementHasReturnStatements(expression)) {
+      // TODO: Check if it has return statements. It has return statements when the type of the block is not undefined.
+      // if it does, assign type of block to type of IfStatement.
+      const ifStatementTypeVariable = (expression as TypeAnnotatedNode<es.IfStatement>).typeVariable
+      if (ifStatementTypeVariable !== undefined && blockTypeVariable !== undefined) {
+        const result = updateTypeConstraints(ifStatementTypeVariable, blockTypeVariable)
+        if (result) {
+          displayErrorAndTerminate(
+            'WARNING: There is a type error when checking the type of a block', block.loc
+          )
+        }
         return
       }
     }

--- a/src/inferencer/inferencer.ts
+++ b/src/inferencer/inferencer.ts
@@ -27,464 +27,501 @@ import {
   printTypeEnvironment
 } from '../utils/inferencerUtils'
 
-// // main function that will infer a program
-export function inferProgram(program: es.Program): TypeAnnotatedNode<es.Program> {
-  function inferLiteral(literal: TypeAnnotatedNode<es.Literal>) {
-    const valueOfLiteral = literal.value
-    if (typeof valueOfLiteral === 'number') {
-      literal.inferredType = numberType
-    } else if (typeof valueOfLiteral === 'boolean') {
-      literal.inferredType = booleanType
-    } else if (typeof valueOfLiteral === 'string') {
-      literal.inferredType = stringType
-    } else if (typeof valueOfLiteral === 'undefined') {
-      literal.inferredType = undefinedType
-    } else {
-      literal.typability = 'Untypable'
-      return
-    }
-    literal.typability = 'Typed'
-    // e.g. Given: 1^T2, Set: T2 = number
-    // e.g. Given: true^T2, Set: T2 = boolean
-    // e.g. Given: 'hi'^T2, Set: T2 = string
-    // todo: undefined gives an object in type environment, handle properly
-    addTypeConstraintForLiteralPrimitive(literal)
+function inferLiteral(literal: TypeAnnotatedNode<es.Literal>) {
+  const valueOfLiteral = literal.value
+  if (typeof valueOfLiteral === 'number') {
+    literal.inferredType = numberType
+  } else if (typeof valueOfLiteral === 'boolean') {
+    literal.inferredType = booleanType
+  } else if (typeof valueOfLiteral === 'string') {
+    literal.inferredType = stringType
+  } else if (typeof valueOfLiteral === 'undefined') {
+    literal.inferredType = undefinedType
+  } else {
+    literal.typability = 'Untypable'
+    return
   }
+  literal.typability = 'Typed'
+  // e.g. Given: 1^T2, Set: T2 = number
+  // e.g. Given: true^T2, Set: T2 = boolean
+  // e.g. Given: 'hi'^T2, Set: T2 = string
+  // todo: undefined gives an object in type environment, handle properly
+  addTypeConstraintForLiteralPrimitive(literal)
+}
 
-  function inferIdentifier(identifier: TypeAnnotatedNode<es.Identifier>) {
-    // Update type constraints in constraintStore
-    // e.g. Given: x^T2, Set: T2 = Γ[x]
-    const idenTypeVariable = identifier.typeVariable as Variable
-    const idenTypeEnvType = primitiveMap.get(identifier.name).types[0] // Type obj
+function inferIdentifier(identifier: TypeAnnotatedNode<es.Identifier>) {
+  // Update type constraints in constraintStore
+  // e.g. Given: x^T2, Set: T2 = Γ[x]
+  const idenTypeVariable = identifier.typeVariable as Variable
+  const idenTypeEnvType = primitiveMap.get(identifier.name).types[0] // Type obj
 
-    if (idenTypeVariable !== undefined && idenTypeEnvType !== undefined) {
-      const result = updateTypeConstraints(idenTypeVariable, idenTypeEnvType)
-      if (result !== undefined) {
-        displayErrorAndTerminate(
-          'WARNING: There should not be a type error here in `inferIdentifier()` - pls debug',
-          identifier.loc
-        )
-      }
-    }
-
-    // declare - Todo: do I need to declare? TBC
-    // - not necessary since it itself is 'not a type'? e.g. 'x;' -> there's no type to x? - TBC
-    // identifier.inferredType = {
-    //   kind: '??',
-    //   type: '??'
-    // }
-    // literal.typability = 'Typed'
-  }
-
-  function inferConstantDeclaration(
-    constantDeclaration: TypeAnnotatedNode<es.VariableDeclaration>
-  ) {
-    // Update type constraints in constraintStore
-    // e.g. Given: const x^T1 = 1^T2, Set: T1 = T2
-    const iden = constantDeclaration.declarations[0].id as TypeAnnotatedNode<es.Identifier>
-    const idenTypeVariable = iden.typeVariable as Variable
-
-    const value = constantDeclaration.declarations[0].init as TypeAnnotatedNode<es.Node> // use es.Node because rhs could be any value/expression
-    const valueTypeVariable = value.typeVariable as Variable
-
-    if (idenTypeVariable !== undefined && valueTypeVariable !== undefined) {
-      const result = updateTypeConstraints(idenTypeVariable, valueTypeVariable)
-      if (result !== undefined) {
-        displayErrorAndTerminate(
-          'WARNING: There should not be a type error here in `inferConstantDeclaration()` - pls debug',
-          constantDeclaration.loc
-        )
-      }
-    }
-
-    // if manage to pass step 3, means no type error
-
-    // declare - Todo: do I need to declare? TBC
-    // - not necessary since no one is dependent on constantDeclaration's inferredType?? - TBC
-    // - plus not sure what to put in 'kind' and 'name' also
-    // constantDeclaration.inferredType = {
-    //   kind: 'variable',
-    //   name: variableType
-    // }
-    // constantDeclaration.typability = 'Typed'
-  }
-
-  function inferUnaryExpression(unaryExpression: TypeAnnotatedNode<es.UnaryExpression>) {
-    // get data about unary expression from type environment
-    const operator = unaryExpression.operator
-    // retrieves function type of unary '-'
-    const typeOfOperator = isOverLoaded(operator)
-      ? primitiveMap.get(operator).types[1]
-      : primitiveMap.get(operator).types[0]
-    const operatorArgType = typeOfOperator.parameterTypes[0]
-    const operatorResultType = typeOfOperator.returnType
-
-    // get data about arguments
-    const argument = unaryExpression.argument as TypeAnnotatedNode<es.UnaryExpression>
-    const argumentTypeVariable = argument.typeVariable as Variable
-    const resultTypeVariable = unaryExpression.typeVariable as Variable
-
-    if (operatorArgType !== undefined && argumentTypeVariable !== undefined) {
-      const result = updateTypeConstraints(argumentTypeVariable, operatorArgType)
-      if (result !== undefined) {
-        displayErrorAndTerminate(
-          `Expecting type \`${printType(operatorArgType)}\` but got \`${printType(
-            argumentTypeVariable
-          )} + \` instead`,
-          unaryExpression.loc
-        )
-      }
-    }
-
-    if (operatorResultType !== undefined && resultTypeVariable !== undefined) {
-      const result = updateTypeConstraints(resultTypeVariable, operatorResultType)
-      if (result !== undefined) {
-        displayErrorAndTerminate(
-          `Expecting type \`${printType(operatorResultType)}\` but got \`${printType(
-            resultTypeVariable
-          )} + \` instead`,
-          unaryExpression.loc
-        )
-      }
-    }
-  }
-
-  function inferBinaryExpression(binaryExpression: TypeAnnotatedNode<es.BinaryExpression>) {
-    // Given operator, get arg and result types of binary expression from type env
-    const primitiveMapTypes = primitiveMap.get(binaryExpression.operator).types
-    let functionType
-
-    // Only take the one for BinaryExpression where num params = 2 (e.g. in the case of overloaded '-')
-    for (const type of primitiveMapTypes) {
-      if (type.parameterTypes && type.parameterTypes.length === 2) {
-        functionType = type
-      }
-    }
-
-    // Additional logic for polymorphic case
-    // E.g. `A1, A1 -> A1`
-    // Becomes `A10, A10 -> A10` after generating fresh type variables
-    if (functionType.isPolymorphic) {
-      const tmpMap = new Map() // tracks old TVariable, new TVariable
-      replaceTypeVariablesWithFreshTypeVariables(functionType, tmpMap)
-    }
-
-    const param1Type = functionType.parameterTypes[0]
-    const param2Type = functionType.parameterTypes[1]
-    const returnType = functionType.returnType
-
-    // Update type constraints in constraintStore
-    // e.g. Given: (x^T1 * 1^T2)^T3, Set: T1 = number, T2 = number, T3 = number
-    const param1 = binaryExpression.left as TypeAnnotatedNode<es.Node> // can be identifier or literal or something else?
-    const param1TypeVariable = param1.typeVariable as Variable
-
-    const param2 = binaryExpression.right as TypeAnnotatedNode<es.Node> // can be identifier or literal or something else?
-    const param2TypeVariable = param2.typeVariable as Variable
-
-    const resultTypeVariable = binaryExpression.typeVariable as Variable
-
-    if (param1TypeVariable !== undefined && param1Type !== undefined) {
-      const result = updateTypeConstraints(param1TypeVariable, param1Type)
-      if (result !== undefined && result.constraintRhs) {
-        if (!functionType.isPolymorphic)
-          displayErrorAndTerminate(
-            `Expecting type \`${param1Type.name}\` but got \`${result.constraintRhs.name}\` instead`,
-            param1.loc
-          )
-        else displayErrorAndTerminate('Polymorphic type error, error msg TBC', param1.loc)
-      }
-    }
-
-    if (param2TypeVariable !== undefined && param2Type !== undefined) {
-      const result = updateTypeConstraints(param2TypeVariable, param2Type)
-      if (result !== undefined && result.constraintRhs) {
-        if (!functionType.isPolymorphic)
-          displayErrorAndTerminate(
-            `Expecting type \`${param2Type.name}\` but got \`${result.constraintRhs.name}\` instead`,
-            param2.loc
-          )
-        else displayErrorAndTerminate('Polymorphic type error, error msg TBC', param2.loc)
-      }
-    }
-
-    if (resultTypeVariable !== undefined && returnType !== undefined) {
-      const result = updateTypeConstraints(resultTypeVariable, returnType)
-      if (result !== undefined && result.constraintRhs) {
-        if (!functionType.isPolymorphic)
-          displayErrorAndTerminate(
-            `Expecting type \` ${returnType.name}\` but got \`${result.constraintRhs.name}\` instead`,
-            binaryExpression.loc
-          )
-        else displayErrorAndTerminate('Polymorphic type error, error msg TBC', binaryExpression.loc)
-      }
-    }
-
-    // declare - Todo: do I need to declare? TBC
-    // binaryExpression.inferredType = {
-    //   kind : 'primitive',
-    //   name: resultType
-    // }
-    // binaryExpression.typability = 'Typed'
-  }
-
-  function inferConditionals(
-    conditionalExpression: TypeAnnotatedNode<es.ConditionalExpression | es.IfStatement>
-  ) {
-    const expressionTypeVariable = conditionalExpression.typeVariable as Variable
-    const test = conditionalExpression.test as TypeAnnotatedNode<es.Expression>
-    const consequent = conditionalExpression.consequent as TypeAnnotatedNode<es.Expression>
-    const alternate = conditionalExpression.alternate as TypeAnnotatedNode<es.Expression>
-
-    // check that the type of the test expression is boolean
-    // const testTypeVariable = (test.typeVariable as Variable).id
-    const testTypeVariable = test.typeVariable as Variable
-    if (testTypeVariable !== undefined) {
-      const result = updateTypeConstraints(testTypeVariable, booleanType)
-      if (result !== undefined) {
-        displayErrorAndTerminate(
-          `Expecting type of test expression to be a \`boolean\` but got \` ${printType(
-            testTypeVariable
-          )}\` instead`,
-          test.loc
-        )
-      }
-    }
-
-    // check that the types of the test expressions are the same
-    const consequentTypeVariable = consequent.typeVariable as Variable
-    const alternateTypeVariable = alternate.typeVariable as Variable
-    if (consequentTypeVariable !== undefined && alternateTypeVariable !== undefined) {
-      const result = updateTypeConstraints(consequentTypeVariable, alternateTypeVariable)
-      if (result !== undefined) {
-        displayErrorAndTerminate(
-          `Expecting consequent type \`${printType(
-            consequentTypeVariable
-          )}\` and alternate type \`${printType(
-            alternateTypeVariable
-          )}\` to be the same, but got different`,
-          consequent.loc
-        )
-      } else {
-        updateTypeConstraints(expressionTypeVariable, consequentTypeVariable)
-      }
-    }
-  }
-
-  function inferReturnStatement(returnStatement: TypeAnnotatedNode<es.ReturnStatement>) {
-    // Update type constraints in constraintStore
-    // e.g. Given: (return (...)^T1)^T2, Set: T2 = T1
-    const arg = returnStatement.argument as TypeAnnotatedNode<es.Node>
-    const argTypeVariable = arg.typeVariable as Variable
-
-    const returnypeVariable = returnStatement.typeVariable as Variable
-
-    if (returnypeVariable !== undefined && argTypeVariable !== undefined) {
-      const errorObj = updateTypeConstraints(returnypeVariable, argTypeVariable)
-      if (errorObj) {
-        // type error
-        displayErrorAndTerminate(
-          'WARNING: There should not be a type error here in `inferReturnStatement()` - pls debug',
-          returnStatement.loc
-        )
-      }
-    }
-  }
-
-  function inferFunctionDeclaration(
-    functionDeclaration: TypeAnnotatedNode<es.FunctionDeclaration>
-  ) {
-    // Update type constraints in constraintStore
-    // e.g. Given: f^T5 (x^T1) { (return (...))^T2 ... (return (...))^T3 }^T4
-
-    // First, try to add constraints that ensure all ReturnStatements give same type
-    // e.g. T2 = T3
-    const bodyNodes = functionDeclaration.body.body
-    let prevReturnTypeVariable
-    for (const node of bodyNodes) {
-      if (node.type === 'ReturnStatement') {
-        const currReturnTypeVariable = (node as TypeAnnotatedNode<es.ReturnStatement>)
-          .typeVariable as Variable
-        if (prevReturnTypeVariable !== undefined && currReturnTypeVariable !== undefined) {
-          const errorObj = updateTypeConstraints(prevReturnTypeVariable, currReturnTypeVariable)
-          if (errorObj) {
-            displayErrorAndTerminate(
-              'Expecting all return statements to have same type, but encountered a different type',
-              node.loc
-            )
-          }
-        }
-        prevReturnTypeVariable = currReturnTypeVariable
-      }
-    }
-
-    // If the above step executes successfully w/o any Type Error,
-    // Next, add constraint to give the FunctionDeclaration a result type corresponding to the ReturnStatement
-    // e.g. T4 = T3
-    const block = functionDeclaration.body as TypeAnnotatedNode<es.BlockStatement>
-    const blockTypeVariable = block.typeVariable as Variable
-
-    if (blockTypeVariable !== undefined && prevReturnTypeVariable !== undefined) {
-      const errorObj = updateTypeConstraints(blockTypeVariable, prevReturnTypeVariable)
-      if (errorObj) {
-        displayErrorAndTerminate(
-          'WARNING: There should not be a type error here in `inferFunctionDeclaration()` Part B - pls debug',
-          functionDeclaration.loc
-        )
-      }
-    }
-
-    // Finally, add constraint to give the function identifier the corresponding function type
-    // e.g. T5 = [T1] => T4
-    const iden = functionDeclaration.id as TypeAnnotatedNode<es.Identifier>
-    const idenTypeVariable = iden.typeVariable as Variable
-
-    const functionType = primitiveMap.get(iden.name) // Get function type from Type Env since it was added there
-
-    if (idenTypeVariable !== undefined && functionType !== undefined) {
-      const errorObj = updateTypeConstraints(idenTypeVariable, functionType)
-      if (errorObj) {
-        displayErrorAndTerminate(
-          'WARNING: There should not be a type error here in `inferFunctionDeclaration()` Part C - pls debug',
-          functionDeclaration.loc
-        )
-      }
-    }
-  }
-
-  function inferFunctionApplication(functionApplication: TypeAnnotatedNode<es.CallExpression>) {
-    // Update type constraints in constraintStore
-    // e.g. Given: f^T5 (x^T1) { (return (...))^T2 ... (return (...))^T3 }^T4
-    //             f^T7 (1^T6)
-
-    // First, ensure arg nodes have same count as Γ(f)
-    // And try to add constraints that ensure arg nodes have same corresponding types
-    // e.g. T6 = T1
-    const iden = functionApplication.callee as TypeAnnotatedNode<es.Identifier>
-    const applicationArgs = functionApplication.arguments as TypeAnnotatedNode<es.Node>[]
-    const applicationArgCount = applicationArgs.length
-
-    const declarationFunctionType = primitiveMap.get(iden.name).types[0]
-    const declarationArgCount = declarationFunctionType.parameterTypes.length
-
-    if (applicationArgCount !== declarationArgCount) {
-      // check arg count
+  if (idenTypeVariable !== undefined && idenTypeEnvType !== undefined) {
+    const result = updateTypeConstraints(idenTypeVariable, idenTypeEnvType)
+    if (result !== undefined) {
       displayErrorAndTerminate(
-        `Expecting \`${declarationArgCount}\` arguments but got \`${applicationArgCount}\` instead`,
+        'WARNING: There should not be a type error here in `inferIdentifier()` - pls debug',
+        identifier.loc
+      )
+    }
+  }
+
+  // declare - Todo: do I need to declare? TBC
+  // - not necessary since it itself is 'not a type'? e.g. 'x;' -> there's no type to x? - TBC
+  // identifier.inferredType = {
+  //   kind: '??',
+  //   type: '??'
+  // }
+  // literal.typability = 'Typed'
+}
+
+function inferConstantDeclaration(
+  constantDeclaration: TypeAnnotatedNode<es.VariableDeclaration>
+) {
+  // Update type constraints in constraintStore
+  // e.g. Given: const x^T1 = 1^T2, Set: T1 = T2
+  const iden = constantDeclaration.declarations[0].id as TypeAnnotatedNode<es.Identifier>
+  const idenTypeVariable = iden.typeVariable as Variable
+
+  const value = constantDeclaration.declarations[0].init as TypeAnnotatedNode<es.Node> // use es.Node because rhs could be any value/expression
+  const valueTypeVariable = value.typeVariable as Variable
+
+  if (idenTypeVariable !== undefined && valueTypeVariable !== undefined) {
+    const result = updateTypeConstraints(idenTypeVariable, valueTypeVariable)
+    if (result !== undefined) {
+      displayErrorAndTerminate(
+        'WARNING: There should not be a type error here in `inferConstantDeclaration()` - pls debug',
+        constantDeclaration.loc
+      )
+    }
+  }
+
+  // if manage to pass step 3, means no type error
+
+  // declare - Todo: do I need to declare? TBC
+  // - not necessary since no one is dependent on constantDeclaration's inferredType?? - TBC
+  // - plus not sure what to put in 'kind' and 'name' also
+  // constantDeclaration.inferredType = {
+  //   kind: 'variable',
+  //   name: variableType
+  // }
+  // constantDeclaration.typability = 'Typed'
+}
+
+function inferUnaryExpression(unaryExpression: TypeAnnotatedNode<es.UnaryExpression>) {
+  // get data about unary expression from type environment
+  const operator = unaryExpression.operator
+  // retrieves function type of unary '-'
+  const typeOfOperator = isOverLoaded(operator)
+    ? primitiveMap.get(operator).types[1]
+    : primitiveMap.get(operator).types[0]
+  const operatorArgType = typeOfOperator.parameterTypes[0]
+  const operatorResultType = typeOfOperator.returnType
+
+  // get data about arguments
+  const argument = unaryExpression.argument as TypeAnnotatedNode<es.UnaryExpression>
+  const argumentTypeVariable = argument.typeVariable as Variable
+  const resultTypeVariable = unaryExpression.typeVariable as Variable
+
+  if (operatorArgType !== undefined && argumentTypeVariable !== undefined) {
+    const result = updateTypeConstraints(argumentTypeVariable, operatorArgType)
+    if (result !== undefined) {
+      displayErrorAndTerminate(
+        `Expecting type \`${printType(operatorArgType)}\` but got \`${printType(
+          argumentTypeVariable
+        )} + \` instead`,
+        unaryExpression.loc
+      )
+    }
+  }
+
+  if (operatorResultType !== undefined && resultTypeVariable !== undefined) {
+    const result = updateTypeConstraints(resultTypeVariable, operatorResultType)
+    if (result !== undefined) {
+      displayErrorAndTerminate(
+        `Expecting type \`${printType(operatorResultType)}\` but got \`${printType(
+          resultTypeVariable
+        )} + \` instead`,
+        unaryExpression.loc
+      )
+    }
+  }
+}
+
+function inferBinaryExpression(binaryExpression: TypeAnnotatedNode<es.BinaryExpression>) {
+  // Given operator, get arg and result types of binary expression from type env
+  const primitiveMapTypes = primitiveMap.get(binaryExpression.operator).types
+  let functionType
+
+  // Only take the one for BinaryExpression where num params = 2 (e.g. in the case of overloaded '-')
+  for (const type of primitiveMapTypes) {
+    if (type.parameterTypes && type.parameterTypes.length === 2) {
+      functionType = type
+    }
+  }
+
+  // Additional logic for polymorphic case
+  // E.g. `A1, A1 -> A1`
+  // Becomes `A10, A10 -> A10` after generating fresh type variables
+  if (functionType.isPolymorphic) {
+    const tmpMap = new Map() // tracks old TVariable, new TVariable
+    replaceTypeVariablesWithFreshTypeVariables(functionType, tmpMap)
+  }
+
+  const param1Type = functionType.parameterTypes[0]
+  const param2Type = functionType.parameterTypes[1]
+  const returnType = functionType.returnType
+
+  // Update type constraints in constraintStore
+  // e.g. Given: (x^T1 * 1^T2)^T3, Set: T1 = number, T2 = number, T3 = number
+  const param1 = binaryExpression.left as TypeAnnotatedNode<es.Node> // can be identifier or literal or something else?
+  const param1TypeVariable = param1.typeVariable as Variable
+
+  const param2 = binaryExpression.right as TypeAnnotatedNode<es.Node> // can be identifier or literal or something else?
+  const param2TypeVariable = param2.typeVariable as Variable
+
+  const resultTypeVariable = binaryExpression.typeVariable as Variable
+
+  if (param1TypeVariable !== undefined && param1Type !== undefined) {
+    const result = updateTypeConstraints(param1TypeVariable, param1Type)
+    if (result !== undefined && result.constraintRhs) {
+      if (!functionType.isPolymorphic)
+        displayErrorAndTerminate(
+          `Expecting type \`${param1Type.name}\` but got \`${result.constraintRhs.name}\` instead`,
+          param1.loc
+        )
+      else displayErrorAndTerminate('Polymorphic type error, error msg TBC', param1.loc)
+    }
+  }
+
+  if (param2TypeVariable !== undefined && param2Type !== undefined) {
+    const result = updateTypeConstraints(param2TypeVariable, param2Type)
+    if (result !== undefined && result.constraintRhs) {
+      if (!functionType.isPolymorphic)
+        displayErrorAndTerminate(
+          `Expecting type \`${param2Type.name}\` but got \`${result.constraintRhs.name}\` instead`,
+          param2.loc
+        )
+      else displayErrorAndTerminate('Polymorphic type error, error msg TBC', param2.loc)
+    }
+  }
+
+  if (resultTypeVariable !== undefined && returnType !== undefined) {
+    const result = updateTypeConstraints(resultTypeVariable, returnType)
+    if (result !== undefined && result.constraintRhs) {
+      if (!functionType.isPolymorphic)
+        displayErrorAndTerminate(
+          `Expecting type \` ${returnType.name}\` but got \`${result.constraintRhs.name}\` instead`,
+          binaryExpression.loc
+        )
+      else displayErrorAndTerminate('Polymorphic type error, error msg TBC', binaryExpression.loc)
+    }
+  }
+
+  // declare - Todo: do I need to declare? TBC
+  // binaryExpression.inferredType = {
+  //   kind : 'primitive',
+  //   name: resultType
+  // }
+  // binaryExpression.typability = 'Typed'
+}
+
+function inferConditionals(
+  conditionalExpression: TypeAnnotatedNode<es.ConditionalExpression | es.IfStatement>
+) {
+  const expressionTypeVariable = conditionalExpression.typeVariable as Variable
+  const test = conditionalExpression.test as TypeAnnotatedNode<es.Expression>
+  const consequent = conditionalExpression.consequent as TypeAnnotatedNode<es.Expression>
+  const alternate = conditionalExpression.alternate as TypeAnnotatedNode<es.Expression>
+
+  // check that the type of the test expression is boolean
+  // const testTypeVariable = (test.typeVariable as Variable).id
+  const testTypeVariable = test.typeVariable as Variable
+  if (testTypeVariable !== undefined) {
+    const result = updateTypeConstraints(testTypeVariable, booleanType)
+    if (result !== undefined) {
+      displayErrorAndTerminate(
+        `Expecting type of test expression to be a \`boolean\` but got \` ${printType(
+          testTypeVariable
+        )}\` instead`,
+        test.loc
+      )
+    }
+  }
+
+  // check that the types of the test expressions are the same
+  const consequentTypeVariable = consequent.typeVariable as Variable
+  const alternateTypeVariable = alternate.typeVariable as Variable
+  if (consequentTypeVariable !== undefined && alternateTypeVariable !== undefined) {
+    const result = updateTypeConstraints(consequentTypeVariable, alternateTypeVariable)
+    if (result !== undefined) {
+      displayErrorAndTerminate(
+        `Expecting consequent type \`${printType(
+          consequentTypeVariable
+        )}\` and alternate type \`${printType(
+          alternateTypeVariable
+        )}\` to be the same, but got different`,
+        consequent.loc
+      )
+    } else {
+      updateTypeConstraints(expressionTypeVariable, consequentTypeVariable)
+    }
+  }
+}
+
+function inferReturnStatement(returnStatement: TypeAnnotatedNode<es.ReturnStatement>) {
+  // Update type constraints in constraintStore
+  // e.g. Given: (return (...)^T1)^T2, Set: T2 = T1
+  const arg = returnStatement.argument as TypeAnnotatedNode<es.Node>
+  const argTypeVariable = arg.typeVariable as Variable
+
+  const returnypeVariable = returnStatement.typeVariable as Variable
+
+  if (returnypeVariable !== undefined && argTypeVariable !== undefined) {
+    const errorObj = updateTypeConstraints(returnypeVariable, argTypeVariable)
+    if (errorObj) {
+      // type error
+      displayErrorAndTerminate(
+        'WARNING: There should not be a type error here in `inferReturnStatement()` - pls debug',
+        returnStatement.loc
+      )
+    }
+  }
+}
+
+function inferFunctionDeclaration(
+  functionDeclaration: TypeAnnotatedNode<es.FunctionDeclaration>
+) {
+  // Update type constraints in constraintStore
+  // e.g. Given: f^T5 (x^T1) { (return (...))^T2 ... (return (...))^T3 }^T4
+
+  // First, try to add constraints that ensure all ReturnStatements give same type
+  // e.g. T2 = T3
+  const bodyNodes = functionDeclaration.body.body
+  let prevReturnTypeVariable
+  for (const node of bodyNodes) {
+    if (node.type === 'ReturnStatement') {
+      const currReturnTypeVariable = (node as TypeAnnotatedNode<es.ReturnStatement>)
+        .typeVariable as Variable
+      if (prevReturnTypeVariable !== undefined && currReturnTypeVariable !== undefined) {
+        const errorObj = updateTypeConstraints(prevReturnTypeVariable, currReturnTypeVariable)
+        if (errorObj) {
+          displayErrorAndTerminate(
+            'Expecting all return statements to have same type, but encountered a different type',
+            node.loc
+          )
+        }
+      }
+      prevReturnTypeVariable = currReturnTypeVariable
+    }
+  }
+
+  // If the above step executes successfully w/o any Type Error,
+  // Next, add constraint to give the FunctionDeclaration a result type corresponding to the ReturnStatement
+  // e.g. T4 = T3
+  const block = functionDeclaration.body as TypeAnnotatedNode<es.BlockStatement>
+  const blockTypeVariable = block.typeVariable as Variable
+
+  if (blockTypeVariable !== undefined && prevReturnTypeVariable !== undefined) {
+    const errorObj = updateTypeConstraints(blockTypeVariable, prevReturnTypeVariable)
+    if (errorObj) {
+      displayErrorAndTerminate(
+        'WARNING: There should not be a type error here in `inferFunctionDeclaration()` Part B - pls debug',
+        functionDeclaration.loc
+      )
+    }
+  }
+
+  // Finally, add constraint to give the function identifier the corresponding function type
+  // e.g. T5 = [T1] => T4
+  const iden = functionDeclaration.id as TypeAnnotatedNode<es.Identifier>
+  const idenTypeVariable = iden.typeVariable as Variable
+
+  const functionType = primitiveMap.get(iden.name) // Get function type from Type Env since it was added there
+
+  if (idenTypeVariable !== undefined && functionType !== undefined) {
+    const errorObj = updateTypeConstraints(idenTypeVariable, functionType)
+    if (errorObj) {
+      displayErrorAndTerminate(
+        'WARNING: There should not be a type error here in `inferFunctionDeclaration()` Part C - pls debug',
+        functionDeclaration.loc
+      )
+    }
+  }
+}
+
+function inferFunctionApplication(functionApplication: TypeAnnotatedNode<es.CallExpression>) {
+  // Update type constraints in constraintStore
+  // e.g. Given: f^T5 (x^T1) { (return (...))^T2 ... (return (...))^T3 }^T4
+  //             f^T7 (1^T6)
+
+  // First, ensure arg nodes have same count as Γ(f)
+  // And try to add constraints that ensure arg nodes have same corresponding types
+  // e.g. T6 = T1
+  const iden = functionApplication.callee as TypeAnnotatedNode<es.Identifier>
+  const applicationArgs = functionApplication.arguments as TypeAnnotatedNode<es.Node>[]
+  const applicationArgCount = applicationArgs.length
+
+  const declarationFunctionType = primitiveMap.get(iden.name).types[0]
+  const declarationArgCount = declarationFunctionType.parameterTypes.length
+
+  if (applicationArgCount !== declarationArgCount) {
+    // check arg count
+    displayErrorAndTerminate(
+      `Expecting \`${declarationArgCount}\` arguments but got \`${applicationArgCount}\` instead`,
+      functionApplication.loc
+    )
+  }
+
+  for (let i = 0; i < applicationArgs.length; i++) {
+    // add type constraint for each arg
+    const applicationArgTypeVariable = applicationArgs[i].typeVariable as Variable
+    const declarationArgTypeVariable = declarationFunctionType.parameterTypes[i]
+      .typeVariable as Variable
+
+    if (applicationArgTypeVariable && declarationArgTypeVariable) {
+      const errorObj = updateTypeConstraints(
+        applicationArgTypeVariable,
+        declarationArgTypeVariable
+      )
+      if (errorObj) {
+        displayErrorAndTerminate(
+          'Expecting all arguments to have correct type as per function declaration, but encountered a wrong type',
+          applicationArgs[i].loc
+        )
+      }
+    }
+  }
+
+  // If the above step executes successfully w/o any Type Error,
+  // Next, add constraint to give the functionApplication a type corresponding to returnType of functionDeclaration
+  // e.g. T7 = T4
+  const applicationTypeVariable = functionApplication.typeVariable as Variable
+  const resultTypeVariable = declarationFunctionType.returnType
+
+  if (applicationTypeVariable && resultTypeVariable) {
+    const errorObj = updateTypeConstraints(applicationTypeVariable, resultTypeVariable)
+    if (errorObj) {
+      displayErrorAndTerminate(
+        'WARNING: There should not be a type error here in `inferFunctionApplication()` - pls debug',
         functionApplication.loc
       )
     }
+  }
+}
 
-    for (let i = 0; i < applicationArgs.length; i++) {
-      // add type constraint for each arg
-      const applicationArgTypeVariable = applicationArgs[i].typeVariable as Variable
-      const declarationArgTypeVariable = declarationFunctionType.parameterTypes[i]
-        .typeVariable as Variable
+function addTypeConstraintForLiteralPrimitive(literal: TypeAnnotatedNode<es.Literal>) {
+  // Update type constraints in constraintStore
+  // e.g. Given: 1^T2, Set: T2 = number
+  // const lhsVariableId = (literal.typeVariable as Variable).id
+  const literalTypeVariable = literal.typeVariable as Variable
+  // const rhsType = (literal.inferredType as Primitive).name
+  const literalType = literal.inferredType as Primitive
 
-      if (applicationArgTypeVariable && declarationArgTypeVariable) {
-        const errorObj = updateTypeConstraints(
-          applicationArgTypeVariable,
-          declarationArgTypeVariable
-        )
-        if (errorObj) {
-          displayErrorAndTerminate(
-            'Expecting all arguments to have correct type as per function declaration, but encountered a wrong type',
-            applicationArgs[i].loc
-          )
-        }
-      }
-    }
-
-    // If the above step executes successfully w/o any Type Error,
-    // Next, add constraint to give the functionApplication a type corresponding to returnType of functionDeclaration
-    // e.g. T7 = T4
-    const applicationTypeVariable = functionApplication.typeVariable as Variable
-    const resultTypeVariable = declarationFunctionType.returnType
-
-    if (applicationTypeVariable && resultTypeVariable) {
-      const errorObj = updateTypeConstraints(applicationTypeVariable, resultTypeVariable)
-      if (errorObj) {
-        displayErrorAndTerminate(
-          'WARNING: There should not be a type error here in `inferFunctionApplication()` - pls debug',
-          functionApplication.loc
-        )
-      }
+  if (literalTypeVariable !== undefined && literalType !== undefined) {
+    const result = updateTypeConstraints(literalTypeVariable, literalType)
+    if (result !== undefined) {
+      displayErrorAndTerminate(
+        'WARNING: There should not be a type error here in `addTypeConstraintForLiteralPrimitive()` - pls debug',
+        literal.loc
+      )
     }
   }
+}
 
-  function addTypeConstraintForLiteralPrimitive(literal: TypeAnnotatedNode<es.Literal>) {
-    // Update type constraints in constraintStore
-    // e.g. Given: 1^T2, Set: T2 = number
-    // const lhsVariableId = (literal.typeVariable as Variable).id
-    const literalTypeVariable = literal.typeVariable as Variable
-    // const rhsType = (literal.inferredType as Primitive).name
-    const literalType = literal.inferredType as Primitive
-
-    if (literalTypeVariable !== undefined && literalType !== undefined) {
-      const result = updateTypeConstraints(literalTypeVariable, literalType)
-      if (result !== undefined) {
-        displayErrorAndTerminate(
-          'WARNING: There should not be a type error here in `addTypeConstraintForLiteralPrimitive()` - pls debug',
-          literal.loc
-        )
-      }
-    }
-  }
-
-  function replaceTypeVariablesWithFreshTypeVariables(parent: Type, tmpMap: Map<Type, Type>) {
-    if (isFunctionType(parent)) {
-      // Process each paramType iteratively
-      const p = parent as FunctionType
-      for (let i = 0; i < p.parameterTypes.length; i++) {
-        if (isTypeVariable(p.parameterTypes[i])) {
-          let freshTypeVariable
-          if (tmpMap.get(p.parameterTypes[i]) === undefined) {
-            freshTypeVariable = fresh(p.parameterTypes[i] as Variable)
-            tmpMap.set(p.parameterTypes[i], freshTypeVariable) // track mapping for repeated use
-          } else {
-            freshTypeVariable = tmpMap.get(p.parameterTypes[i])
-          }
-          if (freshTypeVariable) p.parameterTypes[i] = freshTypeVariable
-        }
-      }
-
-      // Process returnType
-      if (isTypeVariable(p.returnType)) {
+function replaceTypeVariablesWithFreshTypeVariables(parent: Type, tmpMap: Map<Type, Type>) {
+  if (isFunctionType(parent)) {
+    // Process each paramType iteratively
+    const p = parent as FunctionType
+    for (let i = 0; i < p.parameterTypes.length; i++) {
+      if (isTypeVariable(p.parameterTypes[i])) {
         let freshTypeVariable
-        if (tmpMap.get(p.returnType) === undefined) {
-          freshTypeVariable = fresh(p.returnType as Variable)
-          tmpMap.set(p.returnType, freshTypeVariable) // track mapping for repeated use
+        if (tmpMap.get(p.parameterTypes[i]) === undefined) {
+          freshTypeVariable = fresh(p.parameterTypes[i] as Variable)
+          tmpMap.set(p.parameterTypes[i], freshTypeVariable) // track mapping for repeated use
         } else {
-          freshTypeVariable = tmpMap.get(p.returnType)
+          freshTypeVariable = tmpMap.get(p.parameterTypes[i])
         }
-        if (freshTypeVariable) p.returnType = freshTypeVariable
+        if (freshTypeVariable) p.parameterTypes[i] = freshTypeVariable
       }
     }
+
+    // Process returnType
+    if (isTypeVariable(p.returnType)) {
+      let freshTypeVariable
+      if (tmpMap.get(p.returnType) === undefined) {
+        freshTypeVariable = fresh(p.returnType as Variable)
+        tmpMap.set(p.returnType, freshTypeVariable) // track mapping for repeated use
+      } else {
+        freshTypeVariable = tmpMap.get(p.returnType)
+      }
+      if (freshTypeVariable) p.returnType = freshTypeVariable
+    }
   }
+}
 
-  function displayErrorAndTerminate(errorMsg: string, loc: es.SourceLocation | null | undefined) {
-    logObjectsForDebugging()
-    console.log('!!! Type check error !!!')
-
-    // Print error msg with optional location (if exists)
-    if (loc) console.log(`${errorMsg} (line: ${loc.start.line}, char: ${loc.start.column})`)
-    else console.log(errorMsg)
-
-    console.log('\nTerminating program..')
-    return process.exit(0)
+function infer(statement: es.Node) {
+  console.log(statement.type)
+  switch (statement.type) {
+    case "BlockStatement": {
+      inferBlockStatement(statement)
+      return
+    }
+    case "Literal": {
+      inferLiteral(statement)
+      return
+    }
+    case "Identifier": {
+      inferIdentifier(statement)
+      return
+    }
+    case "VariableDeclaration": {
+      inferConstantDeclaration(statement)
+      return
+    }
+    case "UnaryExpression": {
+      inferUnaryExpression(statement)
+      return
+    }
+    case "BinaryExpression": {
+      inferBinaryExpression(statement)
+      return
+    }
+    case "ConditionalExpression": {
+      inferConditionals(statement)
+      return
+    }
+    case "IfStatement": {
+      inferConditionals(statement)
+      return
+    }
+    default: {
+      console.log("Not implemented yet!")
+      return
+    }
   }
+}
 
-  function logObjectsForDebugging() {
-    // for Debugging output
-    console.log('\n--------------')
-    printTypeAnnotation(program)
-    printTypeEnvironment(primitiveMap)
-    printTypeConstraints(constraintStore)
-  }
+function displayErrorAndTerminate(errorMsg: string, loc: es.SourceLocation | null | undefined) {
+  logObjectsForDebugging()
+  console.log('!!! Type check error !!!')
 
-  /////////////////////////////////
-  // Main flow
-  /////////////////////////////////
+  // Print error msg with optional location (if exists)
+  if (loc) console.log(`${errorMsg} (line: ${loc.start.line}, char: ${loc.start.column})`)
+  else console.log(errorMsg)
 
+  console.log('\nTerminating program..')
+  return process.exit(0)
+}
+
+function logObjectsForDebugging(program: es.Program) {
+  // for Debugging output
+  console.log('\n--------------')
+  printTypeAnnotation(program)
+  printTypeEnvironment(primitiveMap)
+  printTypeConstraints(constraintStore)
+}
+// // main function that will infer a program
+export function inferProgram(program: es.Program): TypeAnnotatedNode<es.Program> {
   // Step 1. Annotate program
   program = annotateProgram(program)
 
@@ -493,9 +530,6 @@ export function inferProgram(program: es.Program): TypeAnnotatedNode<es.Program>
 
   // Step 3. Update and solve type constraints
   ancestor(program as es.Node, {
-    Literal: inferLiteral,
-    Identifier: inferIdentifier,
-    VariableDeclaration: inferConstantDeclaration, // Source 1 only has constant declaration
     UnaryExpression: inferUnaryExpression,
     BinaryExpression: inferBinaryExpression,
     ConditionalExpression: inferConditionals,
@@ -505,8 +539,9 @@ export function inferProgram(program: es.Program): TypeAnnotatedNode<es.Program>
     IfStatement: inferConditionals
   })
 
+
   // Successful run..
-  logObjectsForDebugging()
+  logObjectsForDebugging(program)
   // return the AST with annotated types
   return program
 }

--- a/src/inferencer/inferencer.ts
+++ b/src/inferencer/inferencer.ts
@@ -477,13 +477,11 @@ function blockStatementHasReturnStatements(block: TypeAnnotatedNode<es.BlockStat
 }
 
 function inferBlockStatement(block: TypeAnnotatedNode<es.BlockStatement>, environmentToExtend: Map<any, any>) {
-  // TODO: Implement type environment scoping
   currentTypeEnvironment = extendEnvironment(environmentToExtend)
   const blockTypeVariable = block.typeVariable
   for (const expression of block.body) {
     infer(expression, environmentToExtend)
     if (expression.type === 'ReturnStatement') {
-      // TODO: add type constraint for return statements
       const returnStatementTypeVariable = (expression as TypeAnnotatedNode<es.ReturnStatement>).typeVariable
       if (returnStatementTypeVariable !== undefined && blockTypeVariable !== undefined) {
         const result = updateTypeConstraints(returnStatementTypeVariable, blockTypeVariable)
@@ -497,8 +495,8 @@ function inferBlockStatement(block: TypeAnnotatedNode<es.BlockStatement>, enviro
     }
 
     if (expression.type === 'IfStatement' && ifStatementHasReturnStatements(expression)) {
-      // TODO: Check if it has return statements. It has return statements when the type of the block is not undefined.
-      // if it does, assign type of block to type of IfStatement.
+      // Check if it has return statements. It has return statements when the type of the block is not undefined.
+      // If it does, assign type of block to type of IfStatement.
       const ifStatementTypeVariable = (expression as TypeAnnotatedNode<es.IfStatement>).typeVariable
       if (ifStatementTypeVariable !== undefined && blockTypeVariable !== undefined) {
         const result = updateTypeConstraints(ifStatementTypeVariable, blockTypeVariable)
@@ -512,7 +510,6 @@ function inferBlockStatement(block: TypeAnnotatedNode<es.BlockStatement>, enviro
     }
   }
 
-  // TODO: else they have undefined type
   if (blockTypeVariable !== undefined) {
     const result = updateTypeConstraints(blockTypeVariable, undefinedType)
     if (result) {
@@ -520,8 +517,6 @@ function inferBlockStatement(block: TypeAnnotatedNode<es.BlockStatement>, enviro
         'WARNING: There is a type error when checking the type of a block', block.loc
       )
     }
-    popEnvironment()
-    currentTypeEnvironment = environments[0]
     return
   }
 }
@@ -579,6 +574,7 @@ function infer(statement: es.Node, environmentToExtend: Map<any, any> = emptyMap
       return
     }
     case 'FunctionDeclaration': {
+      // FIXME: Environment does not seem to be scoped with respect to argument parameters.
       const parameters = new Map()
       for (const param of statement.params) {
         parameters.set((param as es.Identifier).name, { types: [(param as TypeAnnotatedNode<es.Pattern>).typeVariable] })

--- a/src/inferencer/typeEnvironment.ts
+++ b/src/inferencer/typeEnvironment.ts
@@ -10,10 +10,12 @@ export const environments: Map<string, Type>[] = [globalTypeEnvironment]
 export const extendEnvironment = (map: Map<any, any> = emptyMap) => {
   const newTypeEnvironment =  new Map([...environments[0], ...map])
   environments.push(newTypeEnvironment)
+  return environments[environments.length - 1]
 }
 
 export const popEnvironment = () => {
   environments.pop()
+  return environments[environments.length - 1]
 }
 
 // Main function that will update the type environment e.g. for declarations

--- a/src/inferencer/typeEnvironment.ts
+++ b/src/inferencer/typeEnvironment.ts
@@ -51,7 +51,7 @@ export function updateTypeEnvironment(program: es.Program) {
     const block = functionDeclaration.body as TypeAnnotatedNode<es.BlockStatement>
     const blockTypeVariable = block.typeVariable as Variable
 
-    // Todo: How to tell if the function declared is polymorphic? (w/o evaluating the body)
+    // TODO: How to tell if the function declared is polymorphic? (w/o evaluating the body)
     // From the return statement's type variable obj?
     const isPolymorphic = true // set all to true for now and see what happens
     // ...

--- a/src/inferencer/typeEnvironment.ts
+++ b/src/inferencer/typeEnvironment.ts
@@ -4,7 +4,17 @@ import { generateTypeVariable } from './annotator'
 import * as es from 'estree'
 
 // The Type Environment
-export const primitiveMap = new Map()
+export const globalTypeEnvironment = new Map()
+export const emptyMap = new Map()
+export const environments: Map<string, Type>[] = [globalTypeEnvironment]
+export const extendEnvironment = (map: Map<any, any> = emptyMap) => {
+  const newTypeEnvironment =  new Map([...environments[0], ...map])
+  environments.push(newTypeEnvironment)
+}
+
+export const popEnvironment = () => {
+  environments.pop()
+}
 
 // Main function that will update the type environment e.g. for declarations
 export function updateTypeEnvironment(program: es.Program) {
@@ -19,7 +29,7 @@ export function updateTypeEnvironment(program: es.Program) {
     const valueTypeVariable = value.typeVariable as Variable
 
     if (idenName !== undefined && valueTypeVariable !== undefined) {
-      primitiveMap.set(idenName, {
+      globalTypeEnvironment.set(idenName, {
         types: [valueTypeVariable]
       })
     }
@@ -57,7 +67,7 @@ export function updateTypeEnvironment(program: es.Program) {
     // ...
 
     if (idenName !== undefined && blockTypeVariable !== undefined) {
-      primitiveMap.set(idenName, {
+      globalTypeEnvironment.set(idenName, {
         types: [generateFunctionType(paramTypeVariables, blockTypeVariable, isPolymorphic)]
       })
     }
@@ -120,68 +130,68 @@ function generateAddableType() {
 }
 
 // Initiatize Type Environment
-primitiveMap.set('-', {
+globalTypeEnvironment.set('-', {
   types: [
     generateFunctionType([numberType, numberType], numberType),
     generateFunctionType([numberType], numberType)
   ]
 })
-primitiveMap.set('*', {
+globalTypeEnvironment.set('*', {
   types: [generateFunctionType([numberType, numberType], numberType)]
 })
-primitiveMap.set('/', {
+globalTypeEnvironment.set('/', {
   types: [generateFunctionType([numberType, numberType], numberType)]
 })
-primitiveMap.set('%', {
+globalTypeEnvironment.set('%', {
   types: [generateFunctionType([numberType, numberType], numberType)]
 })
-primitiveMap.set('&&', {
+globalTypeEnvironment.set('&&', {
   types: [generateFunctionType([booleanType, variableType], variableType, true)]
 })
-primitiveMap.set('||', {
+globalTypeEnvironment.set('||', {
   types: [generateFunctionType([booleanType, variableType], variableType, true)],
   isPolymorphic: false
 })
-primitiveMap.set('!', {
+globalTypeEnvironment.set('!', {
   types: [generateFunctionType([booleanType], booleanType)]
 })
 
 let newAddableType = generateAddableType()
-primitiveMap.set('+', {
+globalTypeEnvironment.set('+', {
   types: [generateFunctionType([newAddableType, newAddableType], newAddableType, true)]
 })
 
 newAddableType = generateAddableType()
-primitiveMap.set('===', {
+globalTypeEnvironment.set('===', {
   types: [generateFunctionType([variableType, variableType], booleanType, true)]
 })
 
 newAddableType = generateAddableType()
-primitiveMap.set('!==', {
+globalTypeEnvironment.set('!==', {
   types: [generateFunctionType([variableType, variableType], booleanType, true)]
 })
 
 newAddableType = generateAddableType()
-primitiveMap.set('>', {
+globalTypeEnvironment.set('>', {
   types: [generateFunctionType([newAddableType, newAddableType], booleanType, true)]
 })
 
 newAddableType = generateAddableType()
-primitiveMap.set('>=', {
+globalTypeEnvironment.set('>=', {
   types: [generateFunctionType([newAddableType, newAddableType], booleanType, true)]
 })
 
 newAddableType = generateAddableType()
-primitiveMap.set('<', {
+globalTypeEnvironment.set('<', {
   types: [generateFunctionType([newAddableType, newAddableType], booleanType, true)]
 })
 
 newAddableType = generateAddableType()
-primitiveMap.set('<=', {
+globalTypeEnvironment.set('<=', {
   types: [generateFunctionType([newAddableType, newAddableType], booleanType, true)]
 })
 
-// primitiveMap.set('display', {
+// globalTypeEnvironment.set('display', {
 //   types: [
 //     // { argumentTypes: [numberType], resultType: undefined },
 //     // { argumentTypes: [stringType], resultType: undefined }
@@ -189,7 +199,7 @@ primitiveMap.set('<=', {
 //   ],
 //   isPolymorphic: true
 // })
-// primitiveMap.set('error', {
+// globalTypeEnvironment.set('error', {
 //   types: [
 //     // { argumentTypes: [numberType], resultType: undefined },
 //     // { argumentTypes: [stringType], resultType: undefined }
@@ -198,109 +208,109 @@ primitiveMap.set('<=', {
 //   isPolymorphic: true
 // })
 
-primitiveMap.set('Infinity', {
+globalTypeEnvironment.set('Infinity', {
   types: [numberType]
 })
-primitiveMap.set('is_boolean', {
+globalTypeEnvironment.set('is_boolean', {
   types: [generateFunctionType([variableType], booleanType, true)]
 })
-primitiveMap.set('is_function', {
+globalTypeEnvironment.set('is_function', {
   types: [generateFunctionType([variableType], booleanType, true)]
 })
-primitiveMap.set('is_number', {
+globalTypeEnvironment.set('is_number', {
   types: [generateFunctionType([variableType], booleanType, true)]
 })
-primitiveMap.set('is_string', {
+globalTypeEnvironment.set('is_string', {
   types: [generateFunctionType([variableType], booleanType, true)]
 })
-primitiveMap.set('is_undefined', {
+globalTypeEnvironment.set('is_undefined', {
   types: [generateFunctionType([variableType], booleanType, true)]
 })
 
-primitiveMap.set('math_abs', {
+globalTypeEnvironment.set('math_abs', {
   types: [generateFunctionType([numberType], numberType)]
 })
-primitiveMap.set('math_acos', {
+globalTypeEnvironment.set('math_acos', {
   types: [generateFunctionType([numberType], numberType)]
 })
-primitiveMap.set('math_acosh', {
+globalTypeEnvironment.set('math_acosh', {
   types: [generateFunctionType([numberType], numberType)]
 })
-primitiveMap.set('math_asin', {
+globalTypeEnvironment.set('math_asin', {
   types: [generateFunctionType([numberType], numberType)]
 })
-primitiveMap.set('math_asinh', {
+globalTypeEnvironment.set('math_asinh', {
   types: [generateFunctionType([numberType], numberType)]
 })
-primitiveMap.set('math_atan', {
+globalTypeEnvironment.set('math_atan', {
   types: [generateFunctionType([numberType], numberType)]
 })
-primitiveMap.set('math_atan2', {
+globalTypeEnvironment.set('math_atan2', {
   types: [generateFunctionType([numberType, numberType], numberType)]
 })
-primitiveMap.set('math_atanh', {
+globalTypeEnvironment.set('math_atanh', {
   types: [generateFunctionType([numberType], numberType)]
 })
-primitiveMap.set('math_cbrt', {
+globalTypeEnvironment.set('math_cbrt', {
   types: [generateFunctionType([numberType], numberType)]
 })
-primitiveMap.set('math_ceil', {
+globalTypeEnvironment.set('math_ceil', {
   types: [generateFunctionType([numberType], numberType)]
 })
-primitiveMap.set('math_clz32', {
+globalTypeEnvironment.set('math_clz32', {
   types: [generateFunctionType([numberType], numberType)]
 })
-primitiveMap.set('math_cos', {
+globalTypeEnvironment.set('math_cos', {
   types: [generateFunctionType([numberType], numberType)]
 })
-primitiveMap.set('math_cosh', {
+globalTypeEnvironment.set('math_cosh', {
   types: [generateFunctionType([numberType], numberType)]
 })
-primitiveMap.set('math_exp', {
+globalTypeEnvironment.set('math_exp', {
   types: [generateFunctionType([numberType], numberType)]
 })
-primitiveMap.set('math_expml', {
+globalTypeEnvironment.set('math_expml', {
   types: [generateFunctionType([numberType], numberType)]
 })
-primitiveMap.set('math_floor', {
+globalTypeEnvironment.set('math_floor', {
   types: [generateFunctionType([numberType], numberType)]
 })
-primitiveMap.set('math_fround', {
+globalTypeEnvironment.set('math_fround', {
   types: [generateFunctionType([numberType], numberType)]
 })
-// primitiveMap.set('math_hypot', {
+// globalTypeEnvironment.set('math_hypot', {
 // types: [{ argumentTypes: [numberType], resultType: undefined }],
 //   types: [generateFunctionType([variableType], numberType)],  // Todo: Multiple params accepted?
 //   isPolymorphic: true
 // })
-primitiveMap.set('math_imul', {
+globalTypeEnvironment.set('math_imul', {
   types: [generateFunctionType([numberType, numberType], numberType)]
 })
-primitiveMap.set('math_LN2', {
+globalTypeEnvironment.set('math_LN2', {
   types: [numberType]
 })
-primitiveMap.set('math_LN10', {
+globalTypeEnvironment.set('math_LN10', {
   types: [numberType]
 })
-primitiveMap.set('math_log', {
+globalTypeEnvironment.set('math_log', {
   types: [generateFunctionType([numberType], numberType)]
 })
-primitiveMap.set('math_log1p', {
+globalTypeEnvironment.set('math_log1p', {
   types: [generateFunctionType([numberType], numberType)]
 })
-primitiveMap.set('math_log2', {
+globalTypeEnvironment.set('math_log2', {
   types: [generateFunctionType([numberType], numberType)]
 })
-primitiveMap.set('math_LOG2E', {
+globalTypeEnvironment.set('math_LOG2E', {
   types: [numberType]
 })
-primitiveMap.set('math_log10', {
+globalTypeEnvironment.set('math_log10', {
   types: [generateFunctionType([numberType], numberType)]
 })
-primitiveMap.set('math_LOG10E', {
+globalTypeEnvironment.set('math_LOG10E', {
   types: [numberType]
 })
-// primitiveMap.set('math_max', {
+// globalTypeEnvironment.set('math_max', {
 //   // types: [
 //   //   { argumentTypes: [numberType], resultType: undefined },
 //   //   { argumentTypes: [stringType], resultType: undefined }
@@ -308,7 +318,7 @@ primitiveMap.set('math_LOG10E', {
 //   types: [generateFunctionType([variableType], numberType)],  // Todo: Multiple params accepted?
 //   isPolymorphic: true
 // })
-// primitiveMap.set('math_min', {
+// globalTypeEnvironment.set('math_min', {
 //   // types: [
 //   //   { argumentTypes: [numberType], resultType: undefined },
 //   //   { argumentTypes: [stringType], resultType: undefined }
@@ -316,61 +326,61 @@ primitiveMap.set('math_LOG10E', {
 //   types: [generateFunctionType([variableType], numberType)],  // Todo: Multiple params accepted?
 //   isPolymorphic: true
 // })
-primitiveMap.set('math_PI', {
+globalTypeEnvironment.set('math_PI', {
   types: [numberType]
 })
-primitiveMap.set('math_pow', {
+globalTypeEnvironment.set('math_pow', {
   types: [generateFunctionType([numberType, numberType], numberType)]
 })
-primitiveMap.set('math_random', {
+globalTypeEnvironment.set('math_random', {
   types: [generateFunctionType([], numberType)]
 })
-primitiveMap.set('math_round', {
+globalTypeEnvironment.set('math_round', {
   types: [generateFunctionType([numberType], numberType)]
 })
-primitiveMap.set('math_sign', {
+globalTypeEnvironment.set('math_sign', {
   types: [generateFunctionType([numberType], numberType)]
 })
-primitiveMap.set('math_sin', {
+globalTypeEnvironment.set('math_sin', {
   types: [generateFunctionType([numberType], numberType)]
 })
-primitiveMap.set('math_sinh', {
+globalTypeEnvironment.set('math_sinh', {
   types: [generateFunctionType([numberType], numberType)]
 })
-primitiveMap.set('math_sqrt', {
+globalTypeEnvironment.set('math_sqrt', {
   types: [generateFunctionType([numberType], numberType)]
 })
-primitiveMap.set('math_SQRT1_2', {
+globalTypeEnvironment.set('math_SQRT1_2', {
   types: [numberType]
 })
-primitiveMap.set('math_SQRT2', {
+globalTypeEnvironment.set('math_SQRT2', {
   types: [numberType]
 })
-primitiveMap.set('math_tan', {
+globalTypeEnvironment.set('math_tan', {
   types: [generateFunctionType([numberType], numberType)]
 })
-primitiveMap.set('math_tanh', {
+globalTypeEnvironment.set('math_tanh', {
   types: [generateFunctionType([numberType], numberType)]
 })
-primitiveMap.set('math_trunc', {
+globalTypeEnvironment.set('math_trunc', {
   types: [generateFunctionType([numberType], numberType)]
 })
-primitiveMap.set('NaN', {
+globalTypeEnvironment.set('NaN', {
   types: [numberType]
 })
-primitiveMap.set('parse_int', {
+globalTypeEnvironment.set('parse_int', {
   types: [generateFunctionType([stringType, numberType], numberType)]
 })
-primitiveMap.set('prompt', {
+globalTypeEnvironment.set('prompt', {
   types: [generateFunctionType([stringType], stringType)]
 })
-primitiveMap.set('runtime', {
+globalTypeEnvironment.set('runtime', {
   types: [generateFunctionType([], numberType)]
 })
-primitiveMap.set('stringify', {
+globalTypeEnvironment.set('stringify', {
   types: [generateFunctionType([variableType], stringType, true)]
 })
-primitiveMap.set('undefined', {
+globalTypeEnvironment.set('undefined', {
   types: [undefinedType]
 })
 

--- a/src/inferencer/typeEnvironment.ts
+++ b/src/inferencer/typeEnvironment.ts
@@ -163,7 +163,7 @@ globalTypeEnvironment.set('+', {
 
 newAddableType = generateAddableType()
 globalTypeEnvironment.set('===', {
-  types: [generateFunctionType([variableType, variableType], booleanType, true)]
+  types: [generateFunctionType([newAddableType, newAddableType], booleanType, true)]
 })
 
 newAddableType = generateAddableType()


### PR DESCRIPTION
Implemented type inference for blocks. This meant that a few other major changes were made:
- Scoping of type environments, similar to environments in Source. 
- Manually traversing the AST recursively, instead of using the Visitor pattern. 
- Blocks are also assigned a type according to its return statements. 

