### PR TITLE
Modified Rule 9 of the constraint solver

### DIFF
--- a/src/inferencer/constraintStore.ts
+++ b/src/inferencer/constraintStore.ts
@@ -112,11 +112,13 @@ function solveConstraint(constraintLhs: Type, constraintRhs: Type): any | undefi
     addNConstraint(constraintLhs as FunctionType, constraintStore.get(constraintRhs))
   }
   // check for mismatch base types (Rule 9)
-  else if (
+  else if ((
     isBaseType(constraintLhs) &&
     isBaseType(constraintRhs) &&
     (constraintLhs as Primitive).name !== (constraintRhs as Primitive).name
-  ) {
+   ) 
+   || (isFunctionType(constraintLhs) && isBaseType(constraintRhs)) 
+   || (isBaseType(constraintLhs) && isFunctionType(constraintRhs))) {
     console.log('[debug] Error in Rule 9')
     return { constraintLhs, constraintRhs } // for error logging
   } else {


### PR DESCRIPTION
Previously Rule 9 only checked for base types. As a result, a constraint like number = T28 => T29 will not throw a type error.

This commit throws an error if the constraint solver attempts to unify a base type and a function type.